### PR TITLE
Update AmazonSESSample.java

### DIFF
--- a/bundles/com.amazonaws.eclipse.sdk.ui/samples/AmazonSimpleEmailService/AmazonSESSample.java
+++ b/bundles/com.amazonaws.eclipse.sdk.ui/samples/AmazonSimpleEmailService/AmazonSESSample.java
@@ -100,7 +100,9 @@ public class AmazonSESSample {
             // Send the email.
             client.sendEmail(request);
             System.out.println("Email sent!");
-
+        } catch (AmazonClientException ex) {
+            System.out.println("The email was not sent.");
+            System.out.println("Error message: " + ex.getMessage());
         } catch (Exception ex) {
             System.out.println("The email was not sent.");
             System.out.println("Error message: " + ex.getMessage());


### PR DESCRIPTION
Fixing claimed bug: 

Exception AmazonClientException is explicitly thrown on this line but is caught in the outer catch clause with generic exception on line 104. Consider adding a catch clause of this specific exception in the outer try statement.

Repository
BugBust-repo-java
Branch
master
Path
bundles/com.amazonaws.eclipse.sdk.ui/samples/AmazonSimpleEmailService/AmazonSESSample.java
Line
82